### PR TITLE
Additional asserts: true, false and near.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The name of the assert pretty much tells you everything:
 * `assert_nrange!((x..y), b)` -> Will panic if b is within the range [x, y)
 * `assert_true!(a)` -> Will panic if a is not true
 * `assert_false!(b)` -> Will panic if a is not false
+* `assert_near!(a, b, e)` -> Will panic if b is not within +/- e of a; i.e. b is within the range [a - e, a + e]
 
 `debug_*` variants of the macros are also available, which only work on builds with debug assertions enabled (usually builds produced by running `cargo build` or `cargo test` ).
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The name of the assert pretty much tells you everything:
 * `assert_le!(a, b)` -> Will panic if a is not greater than or equal to b
 * `assert_range!((x..y), b)` -> Will panic if b is not within the range [x, y)
 * `assert_nrange!((x..y), b)` -> Will panic if b is within the range [x, y)
+* `assert_true!(a)` -> Will panic if a is not true
+* `assert_false!(b)` -> Will panic if a is not false
 
 `debug_*` variants of the macros are also available, which only work on builds with debug assertions enabled (usually builds produced by running `cargo build` or `cargo test` ).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,102 @@
 //! standard library. These macros provide extremely useful outputs and can be used for
 //! writing better tests.
 
+/// Asserts that the expression is true
+///
+/// # Examples
+/// ```
+/// # #[macro_use] use all_asserts;
+/// let a = false;
+/// #[cfg(should_panic)]
+/// assert_true!(a);
+///
+/// ```
+/// # #[macro_use] use all_asserts;
+/// let a = true;
+/// assert_true!(a);
+/// ```
+///
+#[macro_export]
+macro_rules! assert_true {
+    ($cond:expr $(,)?) => ({
+        match (&$cond) {
+            cond_val => {
+                if !*cond_val {
+                    panic!(r#"assertion failed: `true but here false`"#)
+                }
+            }
+        }
+    });
+    ($cond:expr,) => {
+        assert_true!($cond)
+    };
+    ($cond:expr, $($arg:tt)+) => ({
+        match (&$cond) {
+            cond_val => {
+                if !*cond_val {
+                    panic!(r#"assertion failed: `true but here false`"#)
+                    }
+                }
+            }
+        });
+    }
+
+/// This is a debug-only variant of the [`assert_true`] macro
+///
+/// [`assert_true`]: ./macro.assert_true.html
+#[macro_export]
+macro_rules! debug_assert_true {
+    ($($arg:tt)*) => (if $crate::cfg!(debug_assertions) { assert_true!($($arg)*); })
+}
+
+/// Asserts that the expression is false
+///
+/// # Examples
+/// ```
+/// # #[macro_use] use all_asserts;
+/// let a = true;
+/// #[cfg(should_panic)]
+/// assert_false!(a);
+///
+/// ```
+/// # #[macro_use] use all_asserts;
+/// let a = false;
+/// assert_false!(a);
+/// ```
+///
+#[macro_export]
+macro_rules! assert_false {
+    ($cond:expr $(,)?) => ({
+        match (&$cond) {
+            cond_val => {
+                if *cond_val {
+                    panic!(r#"assertion failed: `false but here true`"#)
+                }
+            }
+        }
+    });
+    ($cond:expr,) => {
+        assert_false!($cond)
+    };
+    ($cond:expr, $($arg:tt)+) => ({
+        match (&$cond) {
+            cond_val => {
+                if *cond_val {
+                    panic!(r#"assertion failed: `false but here true`"#)
+                    }
+                }
+            }
+        });
+    }
+
+/// This is a debug-only variant of the [`assert_false`] macro
+///
+/// [`assert_false`]: ./macro.assert_false.html
+#[macro_export]
+macro_rules! debug_assert_false {
+    ($($arg:tt)*) => (if $crate::cfg!(debug_assertions) { assert_false!($($arg)*); })
+}
+
 /// Asserts that the left hand side expression is greater
 /// than the right hand side expression
 ///
@@ -301,6 +397,24 @@ macro_rules! debug_assert_nrange {
     ($($arg:tt)*) => (if $crate::cfg!(debug_assertions) { assert_nrange!($($arg)*); })
 }
 
+#[test]
+#[should_panic]
+fn panic_when_not_true() {
+    assert_true!(false);
+}
+#[test]
+fn do_not_panic_when_true() {
+    assert_true!(true);
+}
+#[test]
+#[should_panic]
+fn panic_when_not_false() {
+    assert_false!(true);
+}
+#[test]
+fn do_not_panic_when_false() {
+    assert_false!(false);
+}
 #[test]
 #[should_panic]
 fn panic_when_not_gt() {


### PR DESCRIPTION
This adds three asserts informed by using the Google Test C++ test framework. These are:

- assert_true!() // check if the item under test evaluates to true
- assert_false!() // check if the item under test evaluates to false
- assert_near!() // check if the first element is within the third element (an epsilon) of the second element, especially for checking equality of floating point values.